### PR TITLE
Added link to documentation files

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -18,7 +18,7 @@ Documentation
 =============
 
 Full documentation can be found at `readthedocs <http://oemof.readthedocs.org>`_. Use the `project site <http://readthedocs.org/projects/oemof>`_ of readthedocs to choose the version of the documentation. To get the latest news visit and follow our `website <https://www.oemof.org>`_.
-To download the documentation of the stable version as a file, you can choose from `pdf <http://readthedocs.org/projects/oemof/downloads/pdf/stable/>`_, `html <http://readthedocs.org/projects/oemof/downloads/htmlzip/stable/>`_, or `Epub <http://readthedocs.org/projects/oemof/downloads/epub/stable/>`_. It is also found on `readthedocs <http://oemof.readthedocs.org>`_, by clicking on the arrow in the left lower corner, where you will find also other versions.
+To download the documentation of the stable version as a file, you can choose from `pdf <http://readthedocs.org/projects/oemof/downloads/pdf/stable/>`_, `html <http://readthedocs.org/projects/oemof/downloads/htmlzip/stable/>`_, or `Epub <http://readthedocs.org/projects/oemof/downloads/epub/stable/>`_. It is also found on `readthedocs <http://oemof.readthedocs.org>`_ page, by clicking on the arrow in the left lower corner, where you will find also other versions.
 
 
 Installing oemof


### PR DESCRIPTION
As the link to pdf etc. is not obvious, I added it (stable version) with a quick description how to find it normally.